### PR TITLE
Fix RenderTexture dispose() texture

### DIFF
--- a/starling/textures/RenderTexture.hx
+++ b/starling/textures/RenderTexture.hx
@@ -155,7 +155,10 @@ class RenderTexture extends SubTexture
     /** @inheritDoc */
     public override function dispose():Void
     {
-        _activeTexture.dispose();
+		// if _ownsParent is true _activeTexture will be disposed by the super.dispose() call
+		if (!_ownsParent) {
+			_activeTexture.dispose();	
+		}
         
         if (isDoubleBuffered)
         {


### PR DESCRIPTION
_activeTexture was being disposed twice once in RenderTexture and once in SubTexture
Only dispose it in RenderTexture if SubTexture isn't going to dispose it.