### PR TITLE
look for "_pack_exclude.txt" during graphics loading

### DIFF
--- a/haxegon/Gfx.hx
+++ b/haxegon/Gfx.hx
@@ -1415,6 +1415,12 @@ class Gfx {
 			starlingassets = new AssetManager();
 			starlingassets.verbose = false;
 			
+			var exclusions:Array<String> = [];
+			//Check for packed texture exclusion list
+			if(Assets.exists("data/text/_pack_exclude.txt")) {
+				exclusions = Data.loadtext("_pack_exclude");
+			}
+
 			//Scan for packed textures
 			var atlasnum:Int = 0;
 			for (t in Assets.list(AssetType.TEXT)) {
@@ -1431,9 +1437,12 @@ class Gfx {
 						
 						//Ok, now we work though the XML and load all the images
 						for (i in xml.elementsNamed("SubTexture")) {
-							loadimagefrompackedtexture(i.get("name"), getassetpackedtexture(i.get("name")));
+							var iname = i.get("name");
+							if(exclusions.indexOf(iname) == -1) {
+								//Include all image nodes that aren't explicitly excluded
+								loadimagefrompackedtexture(iname, getassetpackedtexture(iname));
+							}
 						}
-						//for(i in xml.
 					}
 				}
 			}


### PR DESCRIPTION
When using Polymod, texture packs present an obstacle for modders because there's no easy way to include a loose image file (the format they're most comfortable with). Modders could modify and replace the packed texture asset directly, but the trouble with this is that this presents an obstacles to mixing & matching mods.

A solution for this is to provide a simple list of texture asset nodes to exclude from the initial asset index load, that Haxegon always looks for. If this list is provided, then a modder can specify which asset names should be skipped over when Haxegon is caching texture pack asset nodes.

The modder must then a) provide their file, and b) append a line to `data/text/_pack_exclude.txt`

Since `_pack_exclude.txt` is a simple flat file, it will work nicely with append functionality in Polymod.

This seems minimally invasive to Haxegon, shouldn't break any existing projects, and makes all Haxegon games more easily moddable by default.