### PR TITLE
Better error messages

### DIFF
--- a/haxegon/Scene.hx
+++ b/haxegon/Scene.hx
@@ -57,7 +57,7 @@ class Scene {
 		callscenemethod(scenelist[currentscene], "render");
 	}
 	
-	private static function callscenemethod(scene:Dynamic, method:String) {
+	private static function callscenemethod(scene:Dynamic, method:String, ?pos:haxe.PosInfos) {
 		var instanceFunc:Dynamic = Reflect.field(scene, method);
 		if (instanceFunc != null && Reflect.isFunction(instanceFunc)) {
 			try {
@@ -65,7 +65,8 @@ class Scene {
 			} catch ( e:ArgumentError ) {
 				throw( "ERROR in callscenemethod("+scene+","+method+"): Couldn't call " + Type.getClassName(scene) + "." + method + "() without any arguments.");
 			} catch (msg:Dynamic ) {
-				throw( "ERROR in callscenemethod("+scene+","+method+"): instance " + Type.getClassName(scene) + "." + method + "() threw : " + msg);
+				var stack = haxe.CallStack.toString(haxe.CallStack.exceptionStack());
+				throw( "ERROR in callscenemethod("+scene+","+method+") instance : " + msg + ", stack = " + stack);
 			}
 			return;
 		}
@@ -78,7 +79,8 @@ class Scene {
 			} catch ( e:ArgumentError ) {
 				throw( "ERROR in callscenemethod("+scene+","+method+"): Couldn't call " + Type.getClassName(scene) + "." + method + "() without any arguments.");
 			} catch ( msg:Dynamic ) {
-				throw( "ERROR in callscenemethod("+scene+","+method+"): static " + Type.getClassName(scene) + "." + method +"() threw : " + msg);
+				var stack = haxe.CallStack.toString(haxe.CallStack.exceptionStack());
+				throw( "ERROR in callscenemethod("+scene+","+method+") static : " + msg + ", stack = " + stack);
 			}
 			return;
 		}

--- a/haxegon/Scene.hx
+++ b/haxegon/Scene.hx
@@ -57,7 +57,7 @@ class Scene {
 		callscenemethod(scenelist[currentscene], "render");
 	}
 	
-	private static function callscenemethod(scene:Dynamic, method:String, ?pos:haxe.PosInfos) {
+	private static function callscenemethod(scene:Dynamic, method:String) {
 		var instanceFunc:Dynamic = Reflect.field(scene, method);
 		if (instanceFunc != null && Reflect.isFunction(instanceFunc)) {
 			try {

--- a/haxegon/Scene.hx
+++ b/haxegon/Scene.hx
@@ -63,7 +63,9 @@ class Scene {
 			try {
 				Reflect.callMethod(scene, instanceFunc, []);
 			} catch ( e:ArgumentError ) {
-				throw( "ERROR: Couldn't call " + Type.getClassName(scene) + "." + method + "() without any arguments.");
+				throw( "ERROR in callscenemethod("+scene+","+method+"): Couldn't call " + Type.getClassName(scene) + "." + method + "() without any arguments.");
+			} catch (msg:Dynamic ) {
+				throw( "ERROR in callscenemethod("+scene+","+method+"): instance " + Type.getClassName(scene) + "." + method + "() threw : " + msg);
 			}
 			return;
 		}
@@ -74,7 +76,9 @@ class Scene {
 			try {
 				Reflect.callMethod(scene, classFunc, []);
 			} catch ( e:ArgumentError ) {
-				throw( "ERROR: Couldn't call " + Type.getClassName(scene) + "." + method + "() without any arguments.");
+				throw( "ERROR in callscenemethod("+scene+","+method+"): Couldn't call " + Type.getClassName(scene) + "." + method + "() without any arguments.");
+			} catch ( msg:Dynamic ) {
+				throw( "ERROR in callscenemethod("+scene+","+method+"): static " + Type.getClassName(scene) + "." + method +"() threw : " + msg);
 			}
 			return;
 		}


### PR DESCRIPTION
One problem with relying on reflection is that when something crashes you don't necessarily have a good idea of what caused it. Prior to this change I was just getting generic "null object reference." This now gives much more detailed information and helps you track down the root cause of the problem.