### PR TITLE
Revert "Check for the Right Texture Before Disposing"

### DIFF
--- a/starling/textures/RenderTexture.hx
+++ b/starling/textures/RenderTexture.hx
@@ -155,11 +155,18 @@ class RenderTexture extends SubTexture
     /** @inheritDoc */
     public override function dispose():Void
     {
-        if (_helperImage != null) _helperImage.dispose();
-        if ((parent != _bufferTexture) && (_bufferTexture != null)) _bufferTexture.dispose();
-        if (parent != _activeTexture) _activeTexture.dispose();
+		// if _ownsParent is true _activeTexture will be disposed by the super.dispose() call
+		if (!_ownsParent) {
+			_activeTexture.dispose();	
+		}
         
-        super.dispose(); // will take care of parent (either _bufferTexture or _activeTexture)
+        if (isDoubleBuffered)
+        {
+            _bufferTexture.dispose();
+            _helperImage.dispose();
+        }
+        
+        super.dispose();
     }
     
     /** Draws an object into the texture.


### PR DESCRIPTION
As said in https://github.com/haxegon/haxegon/pull/298#issuecomment-425960777 the PR reintroduced the issue we had with black textures/corrupted textures when resizing the window or at random.

Reverting it for now, will investigate later.