### PR TITLE
Fix android compilation

### DIFF
--- a/haxegon/Input.hx
+++ b/haxegon/Input.hx
@@ -402,7 +402,7 @@ class Input {
 		}
 	}
 	
-	public static function getchar():String {
+	public static function get_char():String {
 		if (lastcharcode == -1) return "";
 		return String.fromCharCode(lastcharcode);
 	}	


### PR DESCRIPTION
For some reason `Input.getchar()` causes issues when building it on Android.