### PR TITLE
Update DefaultFont.hx

### DIFF
--- a/haxegon/embeddedassets/DefaultFont.hx
+++ b/haxegon/embeddedassets/DefaultFont.hx
@@ -9,7 +9,7 @@ class DefaultFont {
 	private static var XML_DATA:String = '
 		<font>
 			<info face="default" size="8" bold="0" italic="0" charset="" unicode="1" stretchH="100" smooth="0" aa="1" padding="0,0,0,0" spacing="1,1" outline="0"/>
-			<common lineHeight="8" base="7" scaleW="256" scaleH="22" pages="1" packed="0" alphaChnl="1" redChnl="0" greenChnl="0" blueChnl="0"/>
+			<common lineHeight="9" base="7" scaleW="256" scaleH="22" pages="1" packed="0" alphaChnl="1" redChnl="0" greenChnl="0" blueChnl="0"/>
 			<pages>
 				<page id="0" file="default_0.png" />
 			</pages>


### PR DESCRIPTION
not sure if 'size' should also be increased to 9

before

<img width="556" alt="bildschirmfoto 2019-01-11 um 17 38 52" src="https://user-images.githubusercontent.com/465632/51047337-8295ab00-15c8-11e9-9b00-17923c0a0b2f.png">

after

<img width="555" alt="bildschirmfoto 2019-01-11 um 17 44 00" src="https://user-images.githubusercontent.com/465632/51047346-888b8c00-15c8-11e9-98db-ca21db9c8b3d.png">

fixes #316 ("fixes")
